### PR TITLE
Fix update silent fail

### DIFF
--- a/Launcher/source/Network/http.cpp
+++ b/Launcher/source/Network/http.cpp
@@ -433,7 +433,8 @@ bool downloadFileToDisk(char * url, char*out, wchar_t * sCurrentInfoText, bool &
 	}
 
 	ptr = strcasestr(downloadBuffer, "content-length:");
-	if (!ptr) {
+	if (!ptr) 
+	{
 		return -1;
 	}
 

--- a/Launcher/source/Network/http.cpp
+++ b/Launcher/source/Network/http.cpp
@@ -123,7 +123,7 @@ int downloadFileToBuffer(char * url, char ** buffer, wchar_t * sCurrentInfoText,
 		netBusy = false;
 		return -1;
 	}
-	char * headerformat = "GET %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: PMLauncher %4.2f\r\n\r\n";;
+	char * headerformat = "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: PMLauncher %4.2f\r\n\r\n";;
 
 	char strHeader[strlen(headerformat) + strlen(domain) + strlen(path)];
 	char *r = strHeader;
@@ -192,9 +192,17 @@ int downloadFileToBuffer(char * url, char ** buffer, wchar_t * sCurrentInfoText,
 		return -1;
 	}
 
-	ptr = strstr(downloadBuffer, "Content-Length:");
+	ptr = strcasestr(downloadBuffer, "content-length:");
+	if (!ptr) {
+		return -1;
+	}
+
+	// ensure chars match case we expect
+	for (int i = 0; i < 15; i++) {
+		ptr[i] = tolower(ptr[i]);
+	}
 	u32 filesize;
-	sscanf(ptr, "Content-Length: %u", &filesize);
+	sscanf(ptr, "content-length: %u", &filesize);
 
 	if (sCurrentInfoText)
 		swprintf(sCurrentInfoText, 255, L"Downloading update... (0/%uKB)", filesize / 1024);
@@ -354,7 +362,7 @@ bool downloadFileToDisk(char * url, char*out, wchar_t * sCurrentInfoText, bool &
 		return false;
 	}
 
-	char * headerformat = "GET %s HTTP/1.0\r\nHost: %s\r\nUser-Agent: PMLauncher %4.2f\r\n\r\n";;
+	char * headerformat = "GET %s HTTP/1.1\r\nHost: %s\r\nUser-Agent: PMLauncher %4.2f\r\n\r\n";;
 
 	char strHeader[strlen(headerformat) + strlen(domain) + strlen(path)];
 	char *r = strHeader;
@@ -423,9 +431,17 @@ bool downloadFileToDisk(char * url, char*out, wchar_t * sCurrentInfoText, bool &
 		return false;
 	}
 
-	ptr = strstr(downloadBuffer, "Content-Length:");
+	ptr = strcasestr(downloadBuffer, "content-length:");
+	if (!ptr) {
+		return -1;
+	}
+
+	// ensure chars match case we expect
+	for (int i = 0; i < 15; i++) {
+		ptr[i] = tolower(ptr[i]);
+	}
 	u32 filesize;
-	sscanf(ptr, "Content-Length: %u", &filesize);
+	sscanf(ptr, "content-length: %u", &filesize);
 
 	if (filesize <= 0)
 	{

--- a/Launcher/source/Network/http.cpp
+++ b/Launcher/source/Network/http.cpp
@@ -193,7 +193,8 @@ int downloadFileToBuffer(char * url, char ** buffer, wchar_t * sCurrentInfoText,
 	}
 
 	ptr = strcasestr(downloadBuffer, "content-length:");
-	if (!ptr) {
+	if (!ptr) 
+	{
 		return -1;
 	}
 

--- a/Launcher/source/Network/networkloader.cpp
+++ b/Launcher/source/Network/networkloader.cpp
@@ -134,7 +134,8 @@ void * networkThreadFunction()
 			else
 			{
 				cur = cur->FirstChildElement("news");
-				if (!cur) {
+				if (!cur) 
+				{
 					failed = true;
 					swprintf(newsText, 4096, L"Failed to parse news...");
 				}

--- a/Launcher/source/Network/networkloader.cpp
+++ b/Launcher/source/Network/networkloader.cpp
@@ -129,12 +129,15 @@ void * networkThreadFunction()
 			if (!cur)
 			{
 				failed = true;
+				swprintf(newsText, 4096, L"Failed to parse news...");
 			}
 			else
 			{
 				cur = cur->FirstChildElement("news");
-				if (!cur)
+				if (!cur) {
 					failed = true;
+					swprintf(newsText, 4096, L"Failed to parse news...");
+				}
 				else
 				{
 					if (cur->FirstChild() && cur->FirstChild()->ToText())
@@ -143,16 +146,22 @@ void * networkThreadFunction()
 						swprintf(newsText, 4096, L"%s", text);
 					}
 					else
+					{
 						failed = true;
+						swprintf(newsText, 4096, L"No news at this time...");
+					}
 				}
 			}
 			if (failed)
-				SleepDuringWork(5000);
+				SleepDuringWork(5 * 60 * 1000);
+				//SleepDuringWork(5000);
 			else
 				SleepDuringWork(5 * 60 * 1000);
 		}
 		else
 		{
+			swprintf(newsText, 4096, L"Failed to download news...");
+			sleep(5);
 		}
 		free(buffer);
 


### PR DESCRIPTION
As a preface, I don't know if this is the current repo used for the launcher, or if the launcher is even being updated anymore. Also, I had do a decent bit of modification to get this to compile on my machine, so there may be other issues caused by that (those changes are not in this pr). 

This PR should fix the infinite hanging that occurs with the launcher's update function.

Currently, when Update is selected in the launcher, it hangs at "Downloading news..." and never finishes. This occurs because the check for HTTP/1.1 200 OK fails. The get request sent by the launcher is using http/1.0, and the server replies with http/1.0, meaning that the check for http/1.1 will _always_ fail. 

Another problem occurs after this is fixed, the launcher then fails on strlen, which is called by sscanf. sscanf receives a null pointer from the strstr call above it because the server sends "content-length", whereas strstr is searching for "Content-Length". 

With both of these changes made, the launcher now checks for updates correctly (and shows no updates available).

I did not get to test the update function itself, since I don't have a windows machine handy to try and make a patch. 